### PR TITLE
ESP8266 compilation error fix

### DIFF
--- a/Adafruit_SSD1331.h
+++ b/Adafruit_SSD1331.h
@@ -26,6 +26,9 @@
 typedef volatile RwReg PortReg;
 typedef uint32_t PortMask;
 #define _BV(b) (1<<(b))
+#elif defined(ESP8266) || defined(ARDUINO_STM32_FEATHER)
+typedef volatile uint32_t PortReg;
+typedef uint32_t PortMask;
 #else
 typedef volatile uint8_t PortReg;
 typedef uint8_t PortMask;


### PR DESCRIPTION
```
Adafruit_SSD1331.cpp:308:15: error: cannot convert 'volatile uint32_t* {aka volatile unsigned int*}' to 'PortReg* {aka volatile unsigned char*}' in assignment
rsportreg = portOutputRegister(digitalPinToPort(_rs));
```
