### PR TITLE
Fix for Feather M0 boards

### DIFF
--- a/Adafruit_SSD1331.h
+++ b/Adafruit_SSD1331.h
@@ -22,13 +22,13 @@
 
 #define gfx_swap(a, b) { uint16_t t = a; a = b; b = t; }
 
-#ifdef __SAM3X8E__
-typedef volatile RwReg PortReg;
-typedef uint32_t PortMask;
-#define _BV(b) (1<<(b))
+#if defined(__SAM3X8E__) || defined(ARDUINO_ARCH_SAMD)
+  typedef volatile RwReg PortReg;
+  typedef uint32_t PortMask;
+  #define _BV(b) (1<<(b))
 #else
-typedef volatile uint8_t PortReg;
-typedef uint8_t PortMask;
+  typedef volatile uint8_t PortReg;
+  typedef uint8_t PortMask;
 #endif
 
 // Select one of these defines to set the pixel color order


### PR DESCRIPTION
Adapts ARM platform specific typedef and #define to include SAMD Arduino derivatives.

Tested with the "test" example