### PR TITLE
Adjust a 'PRECHARGE' command which looks like a typo.

### DIFF
--- a/Adafruit_SSD1331.cpp
+++ b/Adafruit_SSD1331.cpp
@@ -343,7 +343,7 @@ void Adafruit_SSD1331::begin(void) {
     writeCommand(0x64);
     writeCommand(SSD1331_CMD_PRECHARGEB);  	// 0x8B
     writeCommand(0x78);
-    writeCommand(SSD1331_CMD_PRECHARGEA);  	// 0x8C
+    writeCommand(SSD1331_CMD_PRECHARGEC);  	// 0x8C
     writeCommand(0x64);
     writeCommand(SSD1331_CMD_PRECHARGELEVEL);  	// 0xBB
     writeCommand(0x3A);


### PR DESCRIPTION
Sorry if this was intentional - but it looks like the 'C' precharge command is never called and the 'A' one is called twice.

- **Describe the scope of your change--i.e. what the change does and what parts
  of the code were modified.**
There's only one character changed; the macro goes from 0x8A to 0x8C, and the comment says 0x8C, so I think the impact should be minimal.

- **Describe any known limitations with your change.**
None known.

- **Please run any tests or examples that can exercise your modified code.**
I ran the 'test' sketch on a 96x64-px SSD1331 board driven from an ATMega328p 'Nano' board with software SPI.