### PR TITLE
Full support for acceleration and rotation. Optional on-device copyBits and fullscreen text scrolling.

### DIFF
--- a/Adafruit_SSD1331.cpp
+++ b/Adafruit_SSD1331.cpp
@@ -40,41 +40,22 @@
 */
 void Adafruit_SSD1331::setAddrWindow(uint16_t x, uint16_t y, uint16_t w,
                                      uint16_t h) {
+  // The inputs to this will _always_ be pre-clipped
 
-  uint8_t x1 = x;
-  uint8_t y1 = y;
-  if (x1 > 95)
-    x1 = 95;
-  if (y1 > 63)
-    y1 = 63;
+  // True if we're swapping row and column due to rotation
+  bool swap = rotation & 0x01;
 
-  uint8_t x2 = (x + w - 1);
-  uint8_t y2 = (y + h - 1);
-  if (x2 > 95)
-    x2 = 95;
-  if (y2 > 63)
-    y2 = 63;
+  SPI_DC_LOW();  // enter command mode
 
-  if (x1 > x2) {
-    uint8_t t = x2;
-    x2 = x1;
-    x1 = t;
-  }
-  if (y1 > y2) {
-    uint8_t t = y2;
-    y2 = y1;
-    y1 = t;
-  }
+  spiWrite(swap?SSD1331_CMD_SETROW:SSD1331_CMD_SETCOLUMN);
+  spiWrite(x);
+  spiWrite(x + w - 1);
 
-  sendCommand(0x15); // Column addr set
-  sendCommand(x1);
-  sendCommand(x2);
+  spiWrite(swap?SSD1331_CMD_SETCOLUMN:SSD1331_CMD_SETROW); 
+  spiWrite(y);
+  spiWrite(y + h - 1);
 
-  sendCommand(0x75); // Column addr set
-  sendCommand(y1);
-  sendCommand(y2);
-
-  startWrite();
+  SPI_DC_HIGH(); // exit command mode
 }
 
 /**************************************************************************/
@@ -83,18 +64,26 @@ void Adafruit_SSD1331::setAddrWindow(uint16_t x, uint16_t y, uint16_t w,
     Connects to the SSD1331 over SPI and sends initialization procedure commands
     @param    freq  Desired SPI clock frequency
 */
-/**************************************************************************/
+/**************************************************************************/ 
+#if defined SSD1331_COLORORDER_RGB
+static const uint8_t SETREMAP_COLOR_BITS = 0b01100000; // 0x72 - RGB Color
+#else
+static const uint8_t SETREMAP_COLOR_BITS = 0b01100100; // 0x76 - BGR Color
+#endif
+
+// These are the bits to OR into the setremap command for different rotations
+static const uint8_t SETREMAP_ROTATION_0_BITS = 0b00010010;
+static const uint8_t SETREMAP_ROTATION_1_BITS = 0b00000011;
+static const uint8_t SETREMAP_ROTATION_2_BITS = 0b00000000;
+static const uint8_t SETREMAP_ROTATION_3_BITS = 0b00010001;
+
 void Adafruit_SSD1331::begin(uint32_t freq) {
   initSPI(freq);
 
   // Initialization Sequence
   sendCommand(SSD1331_CMD_DISPLAYOFF); // 0xAE
   sendCommand(SSD1331_CMD_SETREMAP);   // 0xA0
-#if defined SSD1331_COLORORDER_RGB
-  sendCommand(0x72); // RGB Color
-#else
-  sendCommand(0x76); // BGR Color
-#endif
+  sendCommand(SETREMAP_COLOR_BITS|SETREMAP_ROTATION_0_BITS);
   sendCommand(SSD1331_CMD_STARTLINE); // 0xA1
   sendCommand(0x0);
   sendCommand(SSD1331_CMD_DISPLAYOFFSET); // 0xA2
@@ -189,66 +178,65 @@ void Adafruit_SSD1331::enableDisplay(boolean enable) {
   sendCommand(enable ? SSD1331_CMD_DISPLAYON : SSD1331_CMD_DISPLAYOFF);
 }
 
-#ifdef SSD1331_ENABLE_ACCELERATION
+inline void Adafruit_SSD1331::spiWriteXY(int16_t x, int16_t y)
+{
+  bool swap = rotation & 0x01;
+  spiWrite(swap?y:x);
+  spiWrite(swap?x:y);
+}
 
-// split the color into channels, with the top bit of each channel in bit 5.
-#define split_color(color) \
-uint8_t r = (color >> 10) & 0x3E;\
-uint8_t g = (color >> 5) & 0x3F;\
-uint8_t b = (color << 1) & 0x3E;
+inline void Adafruit_SSD1331::spiWriteColor(int16_t color)
+{
+  spiWrite((color >> 10) & 0x3E); // red
+  spiWrite((color >> 5) & 0x3F);  // green
+  spiWrite((color << 1) & 0x3E);  // blue
+}
 
 void Adafruit_SSD1331::setRotation(uint8_t r)
 {
-  // Rotation not supported -- do nothing.
+  rotation = (r & 0x03);
+  if (rotation & 1) {
+    // rotated 90 or 270 degrees -- swap width and height
+    _width = HEIGHT;
+    _height = WIDTH;
+  } else {
+    // rotated 0 or 180 -- width and height are as set
+    _width = WIDTH;
+    _height = HEIGHT;
+  }
+  
+  uint8_t remap_bits = SETREMAP_COLOR_BITS;
+  switch (rotation) {
+  case 0:
+    // normal
+    remap_bits |= SETREMAP_ROTATION_0_BITS;
+  break;
+  case 1:
+    // rotated right 90 degrees
+    remap_bits |= SETREMAP_ROTATION_1_BITS;
+  break;
+  case 2:
+    // rotated right 180 degrees
+    remap_bits |= SETREMAP_ROTATION_2_BITS;
+  break;
+  case 3:
+    // rotated right 270 degrees
+    remap_bits |= SETREMAP_ROTATION_3_BITS;
+  break;
+  }
+
+  sendCommand(SSD1331_CMD_SETREMAP);   // 0xA0
+  sendCommand(remap_bits);
 }
 
 /**************************************************************************/
 /*!
-   @brief   Draw a rectangle with no fill color
-    @param    x   Top left corner x coordinate
-    @param    y   Top left corner y coordinate
-    @param    w   Width in pixels
-    @param    h   Height in pixels
-    @param    color 16-bit 5-6-5 Color to draw with
+    @brief      Invert the display (ideally using built-in hardware command)
+    @param   i  True if you want to invert, false to make 'normal'
 */
 /**************************************************************************/
-void Adafruit_SSD1331::drawRect(int16_t x, int16_t y, int16_t w, int16_t h,
-                            uint16_t color) {
-  if (x < 0 || x >= _width || 
-      y < 0 || y >= _height)
-    return;
-
-  int16_t x1 = x + w;
-  int16_t y1 = y + h;
-
-  if (x1 >= _width)
-    x1 = _width - 1;
-  if (y1 >= _height)
-    y1 = _height - 1;
-
-  startWrite();
-
-  split_color(color);
-
-  SPI_DC_LOW();  // enter command mode
-  
-  spiWrite(SSD1331_CMD_FILL); // disble fill
-  spiWrite(0x00);
-  spiWrite(SSD1331_CMD_DRAWRECT); // enter "draw rectangle" mode
-  spiWrite(x); // starting column
-  spiWrite(y); // starting row
-  spiWrite(x1); // finishing column
-  spiWrite(y1); // finishing row
-  spiWrite(r);  // outline color
-  spiWrite(g);
-  spiWrite(b);
-  spiWrite(r);  // fill color (unused, but the command apparently still requires it)
-  spiWrite(g);
-  spiWrite(b);
-
-  SPI_DC_HIGH(); // exit command mode
-
-  endWrite();
+void Adafruit_SSD1331::invertDisplay(bool i) {
+  sendCommand(i?SSD1331_CMD_INVERTDISPLAY:SSD1331_CMD_NORMALDISPLAY);
 }
 
 /**************************************************************************/
@@ -267,19 +255,24 @@ void Adafruit_SSD1331::writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
   int16_t x1 = x + w;
   int16_t y1 = y + h;
 
-  if (x1 < 0 || x >= _width || y1 < 0 || y >= _height)
+  // Bail out if completely off-screen
+  if (x1 < 0 || x >= _width || y1 < 0 || y >= _height) {
     return;
+  }
 
   if (x < 0)
     x = 0;
-  if (x1 >= _width)
-    x1 = _width - 1;
+  if (x1 > _width)
+    x1 = _width;
   if (y < 0)
     y = 0;
-  if (y1 >= _height)
-    y1 = _height - 1;
-
-  // Serial.printf("clipped %d %d %d %d - %d %d\r\n", x, y, x1, y1, _width, _height);
+  if (y1 > _height)
+    y1 = _height;
+  
+  // Bail out if clipped rect is empty
+  if (x1 - 1 < x || y1 - 1 < y) {
+    return;
+  }
 
   SPI_DC_LOW();  // enter command mode
 
@@ -287,10 +280,8 @@ void Adafruit_SSD1331::writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
   {
     // if filling zero, we can use the less expensive clear command (writes 5 bytes over SPI).
     spiWrite(SSD1331_CMD_CLEAR);
-    spiWrite(x); // starting column
-    spiWrite(y); // starting row
-    spiWrite(x1); // finishing column
-    spiWrite(y1); // finishing row
+    spiWriteXY(x, y); // starting column/row
+    spiWriteXY(x1 - 1, y1 - 1); // finishing column/row
   }
   else if (x == x1 || y == y1)
   {
@@ -300,24 +291,25 @@ void Adafruit_SSD1331::writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
   else
   {
     // Use the actual fill-rect command (13 bytes over SPI)
-    split_color(color);
-    
     spiWrite(SSD1331_CMD_FILL); // enable fill
     spiWrite(0x01);
     spiWrite(SSD1331_CMD_DRAWRECT); // enter "draw rectangle" mode
-    spiWrite(x); // starting column
-    spiWrite(y); // starting row
-    spiWrite(x1); // finishing column
-    spiWrite(y1); // finishing row
-    spiWrite(r);  // outline color
-    spiWrite(g);
-    spiWrite(b);
-    spiWrite(r);  // fill color
-    spiWrite(g);
-    spiWrite(b);
+    spiWriteXY(x, y); // starting column/row
+    spiWriteXY(x1 - 1, y1 - 1); // finishing column/row
+    spiWriteColor(color);
+    spiWriteColor(color);
   }
 
   SPI_DC_HIGH(); // exit command mode
+
+  // Filling the pixels sometimes takes long enough that it may be interrupted by subsequent commands, 
+  // and corrupt the data as a result.
+  // Calculate a delay based on the number of pixels written.
+  // For a full-screen fill, we want to delay somewhere above 1000us. 
+  // A full-screen fill is 96 * 64 = 6144 pixels.
+  // Dividing this by 4 gives us 1536us, which is close enough.
+  int delay = (w * h) >> 2;
+  delayMicroseconds(delay);
 }
 
 void Adafruit_SSD1331::writeFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color)
@@ -352,35 +344,148 @@ void Adafruit_SSD1331::writeLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
     return;
   }
 
-  split_color(color);
-
   SPI_DC_LOW();  // enter command mode
 
   spiWrite(SSD1331_CMD_DRAWLINE); // enter "draw rectangle" mode
-  spiWrite(x0); // starting column
-  spiWrite(y0); // starting row
-  spiWrite(x1); // finishing column
-  spiWrite(y1); // finishing row
-  spiWrite(r);  // color
-  spiWrite(g);
-  spiWrite(b);
+  spiWriteXY(x0, y0); // starting column/row
+  spiWriteXY(x1, y1); // finishing column/row
+  spiWriteColor(color);
 
   SPI_DC_HIGH(); // exit command mode
 }
 
-void Adafruit_SSD1331::writePixel(int16_t x, int16_t y, uint16_t color) {
-
-  // Using the Draw Line command writes 8 bytes over SPI. 
-  // Setting the window and pushing one pixel would also use 8, split across multiple transactions.
-  // This is something like 4x faster for text drawing, etc.
-  writeLine(x, y, x, y, color);
+void Adafruit_SSD1331::drawPixel(int16_t x, int16_t y, uint16_t color) {
+  startWrite();
+  writePixel(x, y, color);
+  endWrite();
 }
+
+/**************************************************************************/
+/*!
+   @brief    Draw a perfectly vertical line (this is often optimized in a
+   subclass!)
+    @param    x   Top-most x coordinate
+    @param    y   Top-most y coordinate
+    @param    h   Height in pixels
+   @param    color 16-bit 5-6-5 Color to fill with
+*/
+/**************************************************************************/
+void Adafruit_SSD1331::drawFastVLine(int16_t x, int16_t y, int16_t h,
+                                 uint16_t color) {
+  startWrite();
+  writeFastVLine(x, y, h, color);
+  endWrite();
+}
+
+/**************************************************************************/
+/*!
+   @brief    Draw a perfectly horizontal line (this is often optimized in a
+   subclass!)
+    @param    x   Left-most x coordinate
+    @param    y   Left-most y coordinate
+    @param    w   Width in pixels
+   @param    color 16-bit 5-6-5 Color to fill with
+*/
+/**************************************************************************/
+void Adafruit_SSD1331::drawFastHLine(int16_t x, int16_t y, int16_t w,
+                                 uint16_t color) {
+  startWrite();
+  writeFastHLine(x, y, w, color);
+  endWrite();
+}
+
+/**************************************************************************/
+/*!
+   @brief    Fill a rectangle completely with one color. Update in subclasses if
+   desired!
+    @param    x   Top left corner x coordinate
+    @param    y   Top left corner y coordinate
+    @param    w   Width in pixels
+    @param    h   Height in pixels
+   @param    color 16-bit 5-6-5 Color to fill with
+*/
+/**************************************************************************/
+void Adafruit_SSD1331::fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
+                            uint16_t color) {
+  startWrite();
+  writeFillRect(x, y, w, h, color);
+  endWrite();
+}
+
+/**************************************************************************/
+/*!
+   @brief    Fill the screen completely with one color. Update in subclasses if
+   desired!
+    @param    color 16-bit 5-6-5 Color to fill with
+*/
+/**************************************************************************/
+void Adafruit_SSD1331::fillScreen(uint16_t color) {
+  fillRect(0, 0, _width, _height, color);
+}
+
+/**************************************************************************/
+/*!
+   @brief    Draw a line
+    @param    x0  Start point x coordinate
+    @param    y0  Start point y coordinate
+    @param    x1  End point x coordinate
+    @param    y1  End point y coordinate
+    @param    color 16-bit 5-6-5 Color to draw with
+*/
+/**************************************************************************/
+void Adafruit_SSD1331::drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
+                            uint16_t color) {
+  startWrite();
+  writeLine(x0, y0, x1, y1, color);
+  endWrite();
+}
+/**************************************************************************/
+/*!
+   @brief   Draw a rectangle with no fill color
+    @param    x   Top left corner x coordinate
+    @param    y   Top left corner y coordinate
+    @param    w   Width in pixels
+    @param    h   Height in pixels
+    @param    color 16-bit 5-6-5 Color to draw with
+*/
+/**************************************************************************/
+void Adafruit_SSD1331::drawRect(int16_t x, int16_t y, int16_t w, int16_t h,
+                            uint16_t color) {
+  if (x < 0 || x >= _width || 
+      y < 0 || y >= _height ||
+      w <= 0 || h <= 0)
+    return;
+
+  int16_t x1 = x + w;
+  int16_t y1 = y + h;
+
+  if (x1 > _width)
+    x1 = _width;
+  if (y1 >= _height)
+    y1 = _height;
+
+  startWrite();
+
+  SPI_DC_LOW();  // enter command mode
+  
+  spiWrite(SSD1331_CMD_FILL); // disble fill
+  spiWrite(0x00);
+  spiWrite(SSD1331_CMD_DRAWRECT); // enter "draw rectangle" mode
+  spiWriteXY(x, y); // starting column/row
+  spiWriteXY(x1 - 1, y1 - 1); // finishing column/row
+  spiWriteColor(color);
+  spiWriteColor(color);
+
+  SPI_DC_HIGH(); // exit command mode
+
+  endWrite();
+}
+
+#ifdef SSD1331_EXTRAS
 
 void Adafruit_SSD1331::copyBits(int16_t x, int16_t y, int16_t w, int16_t h,
               int16_t dx, int16_t dy, bool invert)
 {
-  // Serial.printf("copyBits inputs: %d %d %d %d %d %d\r\n", x, y, w, h, dx, dy);
-
   // Clip such that both source and destination are completely contained within the screen bounds.
   int min_x = min(x, dx);
   int max_x = max(x, dx) + w;
@@ -390,7 +495,7 @@ void Adafruit_SSD1331::copyBits(int16_t x, int16_t y, int16_t w, int16_t h,
     dx += clip;
     w -= clip;
   }
-  clip = max_x - (_width - 1);
+  clip = max_x - _width;
   if (clip > 0) {
     w -= clip;
   }
@@ -407,7 +512,7 @@ void Adafruit_SSD1331::copyBits(int16_t x, int16_t y, int16_t w, int16_t h,
     dy += clip;
     h -= clip;
   }
-  clip = max_y - (_height - 1);
+  clip = max_y - _height;
   if (clip > 0) {
     h -= clip;
   }
@@ -416,8 +521,6 @@ void Adafruit_SSD1331::copyBits(int16_t x, int16_t y, int16_t w, int16_t h,
     return;
   }
 
-  // Serial.printf("copyBits clipped: %d %d %d %d %d %d\r\n", x, y, w, h, dx, dy);
-
   startWrite();
 
   SPI_DC_LOW();  // enter command mode
@@ -425,20 +528,17 @@ void Adafruit_SSD1331::copyBits(int16_t x, int16_t y, int16_t w, int16_t h,
   spiWrite(SSD1331_CMD_FILL); // configure invert
   spiWrite(invert?0x10:0x00);
   spiWrite(SSD1331_CMD_COPY); // enter "draw rectangle" mode
-  spiWrite(x); // starting column
-  spiWrite(y); // starting row
-  spiWrite(x + w); // finishing column
-  spiWrite(y + h); // finishing row
-  spiWrite(dx); // destination row
-  spiWrite(dy); // destination column
+  spiWriteXY(x, y); // starting column/row
+  spiWriteXY(x + w - 1, y + h - 1); // finishing column/row
+  spiWriteXY(dx, dy); // destination column/row
   
   SPI_DC_HIGH(); // exit command mode
 
   endWrite();
 
-  // It seems that the copy command sometimes takes long enough that it may be interrupted by subsequent commands, 
+  // Copying the bits sometimes takes long enough that it may be interrupted by subsequent commands, 
   // and corrupt the data as a result.
-  // Calculate a delay based on the number of pixels blitted.
+  // Calculate a delay based on the number of pixels to be blitted.
   // For a full-screen blit, we want to delay somewhere above 1000us. 
   // A full-screen blit is 96 * 64 = 6144 pixels.
   // Dividing this by 4 gives us 1536us, which is close enough.

--- a/Adafruit_SSD1331.cpp
+++ b/Adafruit_SSD1331.cpp
@@ -293,7 +293,7 @@ void Adafruit_SSD1331::writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
     // Use the actual fill-rect command (13 bytes over SPI)
     spiWrite(SSD1331_CMD_FILL); // enable fill
     spiWrite(0x01);
-    spiWrite(SSD1331_CMD_DRAWRECT); // enter "draw rectangle" mode
+    spiWrite(SSD1331_CMD_DRAWRECT); // "draw rectangle" command
     spiWriteXY(x, y); // starting column/row
     spiWriteXY(x1 - 1, y1 - 1); // finishing column/row
     spiWriteColor(color);
@@ -336,17 +336,20 @@ void Adafruit_SSD1331::writeFastHLine(int16_t x, int16_t y, int16_t w, uint16_t 
 void Adafruit_SSD1331::writeLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
                             uint16_t color) {
 
-  // Simple, dumb clip. If either point is outside the screen, don't draw.
-  if (x0 < 0 || x0 >= _width || 
-      x1 < 0 || x1 >= _width || 
-      y0 < 0 || y0 >= _height || 
-      y1 < 0 || y1 >= _height) {
-    return;
-  }
-
+  // Simple clip that gives incorrect results for diagonal lines,
+  // but will at least clip horizontal/vertical lines correctly.
+  if (x0 < 0) x0 = 0;
+  else if (x0 >= _width) x0 = _width - 1;
+  if (x1 < 0) x1 = 0;
+  else if (x1 >= _width) x1 = _width - 1;
+  if (y0 < 0) y0 = 0;
+  else if (y0 >= _height) y0 = _height - 1;
+  if (y1 < 0) y1 = 0;
+  else if (y1 >= _height) y1 = _height - 1;
+  
   SPI_DC_LOW();  // enter command mode
 
-  spiWrite(SSD1331_CMD_DRAWLINE); // enter "draw rectangle" mode
+  spiWrite(SSD1331_CMD_DRAWLINE); // "draw line" command
   spiWriteXY(x0, y0); // starting column/row
   spiWriteXY(x1, y1); // finishing column/row
   spiWriteColor(color);
@@ -470,7 +473,7 @@ void Adafruit_SSD1331::drawRect(int16_t x, int16_t y, int16_t w, int16_t h,
   
   spiWrite(SSD1331_CMD_FILL); // disble fill
   spiWrite(0x00);
-  spiWrite(SSD1331_CMD_DRAWRECT); // enter "draw rectangle" mode
+  spiWrite(SSD1331_CMD_DRAWRECT); // "draw rectangle" command
   spiWriteXY(x, y); // starting column/row
   spiWriteXY(x1 - 1, y1 - 1); // finishing column/row
   spiWriteColor(color);
@@ -527,7 +530,7 @@ void Adafruit_SSD1331::copyBits(int16_t x, int16_t y, int16_t w, int16_t h,
   
   spiWrite(SSD1331_CMD_FILL); // configure invert
   spiWrite(invert?0x10:0x00);
-  spiWrite(SSD1331_CMD_COPY); // enter "draw rectangle" mode
+  spiWrite(SSD1331_CMD_COPY); // bitblt command
   spiWriteXY(x, y); // starting column/row
   spiWriteXY(x + w - 1, y + h - 1); // finishing column/row
   spiWriteXY(dx, dy); // destination column/row

--- a/Adafruit_SSD1331.h
+++ b/Adafruit_SSD1331.h
@@ -8,7 +8,8 @@
 #include <Adafruit_SPITFT_Macros.h>
 #include <SPI.h>
 
-#define SSD1331_ENABLE_ACCELERATION
+// Enable copyBits and setTextScroll 
+#define SSD1331_EXTRAS
 
 /*!
  * @brief Select one of these defines to set the pixel color order
@@ -75,14 +76,14 @@ public:
   static const int16_t TFTWIDTH = 96;  ///< The width of the display
   static const int16_t TFTHEIGHT = 64; ///< The height of the display
 
+#ifdef SSD1331_EXTRAS
+  // If this is set to true, the screen will scroll up when text is printed off the bottom.
   void setTextScroll(bool s) { scroll = s; }
+#endif
 
-#ifdef SSD1331_ENABLE_ACCELERATION
   virtual void setRotation(uint8_t r);
-  virtual void drawRect(int16_t x, int16_t y, int16_t w, int16_t h,
-                        uint16_t color);
+  virtual void invertDisplay(bool i);
 
-  virtual void writePixel(int16_t x, int16_t y, uint16_t color);
   virtual void writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
                              uint16_t color);
   virtual void writeFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
@@ -90,6 +91,18 @@ public:
   virtual void writeLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
                          uint16_t color);
 
+  virtual void drawPixel(int16_t x, int16_t y, uint16_t color);
+  virtual void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
+  virtual void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  virtual void fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
+                        uint16_t color);
+  virtual void fillScreen(uint16_t color);
+  virtual void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
+                        uint16_t color);
+  virtual void drawRect(int16_t x, int16_t y, int16_t w, int16_t h,
+                        uint16_t color);
+
+#ifdef SSD1331_EXTRAS
   // Does a bitblt on the device.
   void copyBits(int16_t x, int16_t y, int16_t w, int16_t h,
                 int16_t dx, int16_t dy, bool invert = false);
@@ -102,4 +115,6 @@ protected:
   bool scroll;
 
 private:
+  void spiWriteXY(int16_t x, int16_t y);
+  void spiWriteColor(int16_t color);
 };

--- a/Adafruit_SSD1331.h
+++ b/Adafruit_SSD1331.h
@@ -8,6 +8,8 @@
 #include <Adafruit_SPITFT_Macros.h>
 #include <SPI.h>
 
+#define SSD1331_ENABLE_ACCELERATION 1
+
 /*!
  * @brief Select one of these defines to set the pixel color order
  */
@@ -25,6 +27,8 @@
 // SSD1331 Commands
 #define SSD1331_CMD_DRAWLINE 0x21      //!< Draw line
 #define SSD1331_CMD_DRAWRECT 0x22      //!< Draw rectangle
+#define SSD1331_CMD_COPY 0x23          //!< Copy
+#define SSD1331_CMD_CLEAR 0x25         //!< Clear
 #define SSD1331_CMD_FILL 0x26          //!< Fill enable/disable
 #define SSD1331_CMD_SETCOLUMN 0x15     //!< Set column address
 #define SSD1331_CMD_SETROW 0x75        //!< Set row adress
@@ -70,6 +74,19 @@ public:
 
   static const int16_t TFTWIDTH = 96;  ///< The width of the display
   static const int16_t TFTHEIGHT = 64; ///< The height of the display
+
+#ifdef SSD1331_ENABLE_ACCELERATION
+  virtual void drawRect(int16_t x, int16_t y, int16_t w, int16_t h,
+                        uint16_t color);
+
+  // virtual void writePixel(int16_t x, int16_t y, uint16_t color);
+  virtual void writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
+                             uint16_t color);
+  // virtual void writeFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
+  // virtual void writeFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  virtual void writeLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
+                         uint16_t color);
+#endif
 
 private:
 };

--- a/Adafruit_SSD1331.h
+++ b/Adafruit_SSD1331.h
@@ -8,7 +8,7 @@
 #include <Adafruit_SPITFT_Macros.h>
 #include <SPI.h>
 
-#define SSD1331_ENABLE_ACCELERATION 1
+#define SSD1331_ENABLE_ACCELERATION
 
 /*!
  * @brief Select one of these defines to set the pixel color order
@@ -75,18 +75,30 @@ public:
   static const int16_t TFTWIDTH = 96;  ///< The width of the display
   static const int16_t TFTHEIGHT = 64; ///< The height of the display
 
+  void setTextScroll(bool s) { scroll = s; }
+
 #ifdef SSD1331_ENABLE_ACCELERATION
   virtual void drawRect(int16_t x, int16_t y, int16_t w, int16_t h,
                         uint16_t color);
 
-  // virtual void writePixel(int16_t x, int16_t y, uint16_t color);
+  virtual void writePixel(int16_t x, int16_t y, uint16_t color);
   virtual void writeFillRect(int16_t x, int16_t y, int16_t w, int16_t h,
                              uint16_t color);
-  // virtual void writeFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
-  // virtual void writeFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  virtual void writeFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
+  virtual void writeFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
   virtual void writeLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
                          uint16_t color);
+
+  // Does a bitblt on the device.
+  void copyBits(int16_t x, int16_t y, int16_t w, int16_t h,
+                int16_t dx, int16_t dy, bool invert = false);
+
+  // Overriding to do full-screen scrolling when text is written past the last line.
+  virtual size_t write(uint8_t);
 #endif
+
+protected:
+  bool scroll;
 
 private:
 };

--- a/Adafruit_SSD1331.h
+++ b/Adafruit_SSD1331.h
@@ -78,6 +78,7 @@ public:
   void setTextScroll(bool s) { scroll = s; }
 
 #ifdef SSD1331_ENABLE_ACCELERATION
+  virtual void setRotation(uint8_t r);
   virtual void drawRect(int16_t x, int16_t y, int16_t w, int16_t h,
                         uint16_t color);
 

--- a/examples/LCDGFXDemo/LCDGFXDemo.ino
+++ b/examples/LCDGFXDemo/LCDGFXDemo.ino
@@ -1,3 +1,4 @@
+// LCDGFXDemo.ino
 // GFX Demo for multiple backends
 // By Marc MERLIN <marc_soft@merlins.org>
 // Contains code (c) Adafruit, license BSD
@@ -6,7 +7,8 @@
 #include <Adafruit_SSD1331.h>
 #include <SPI.h>
 
-#define show endWrite
+// On Adafruit_SSD1331, turn show into a no-op.
+#define show width
 #define clear() fillScreen(0)
 #define mw 96
 #define mh 64
@@ -467,30 +469,33 @@ void display_scrollText() {
     display.setTextSize(1);
     display.setRotation(0);
     for (int8_t x=7; x>=-42; x--) {
-	display.clear();
-	display.setCursor(x,0);
-	display.setTextColor(LED_GREEN_HIGH);
-	display.print("Hello");
-	if (mh>11) {
-	    display.setCursor(-20-x,mh-7);
-	    display.setTextColor(LED_ORANGE_HIGH);
-	    display.print("World");
-	}
-	display.show();
-      // delay(50);
+        display.clear();
+        display.setCursor(x,0);
+        display.setTextColor(LED_GREEN_HIGH);
+        display.print("Hello");
+        if (mh>11) {
+            display.setCursor(-20-x,mh-7);
+            display.setTextColor(LED_ORANGE_HIGH);
+            display.print("World");
+        }
+        display.show();
+        delay(50);
     }
 
-    display.setRotation(1);
-    display.setTextSize(size);
-    display.setTextColor(LED_BLUE_HIGH);
-    for (int16_t x=8*size; x>=-6*8*size; x--) {
-	display.clear();
-	display.setCursor(x,mw/2-size*4);
-	display.print("Rotate");
-	display.show();
-	// note that on a big array the refresh rate from show() will be slow enough that
-	// the delay become irrelevant. This is already true on a 32x32 array.
-       // delay(50/size);
+    for (int i = 0; i < 4; i++)
+    {
+        display.setRotation(i);
+        display.setTextSize(size);
+        display.setTextColor(LED_BLUE_HIGH);
+        for (int16_t x=8*size; x>=-6*8*size; x--) {
+            display.clear();
+            display.setCursor(x,mw/2-size*4);
+            display.printf("Rotate %d", i);
+            display.show();
+            // note that on a big array the refresh rate from show() will be slow enough that
+            // the delay become irrelevant. This is already true on a 32x32 array.
+            delay(50/size);
+        }
     }
     display.setRotation(0);
     display.setCursor(0,0);

--- a/examples/test/test.ino
+++ b/examples/test/test.ino
@@ -56,60 +56,136 @@ void setup(void) {
   display.begin();
 
   Serial.println("init");
-  uint16_t time = millis();
-  display.fillScreen(BLACK);
-  time = millis() - time;
+}
 
-  Serial.println(time, DEC);
+void loop(){
+  for (int i = 0; i < 4; i++)
+  {
+    display.setRotation(i);
+    all_tests();
+  }
+}
+
+void all_tests() {
+  Serial.printf("Running all tests at rotation %d\r\n", display.getRotation());
+  unsigned long time = millis();
+  display.fillScreen(BLACK);
+  Serial.printf("Clear screen took %ldms\r\n", millis() - time);
   delay(500);
 
+  time = millis();
   lcdTestPattern();
+  Serial.printf("Test pattern took %ldms\r\n", millis() - time);
   delay(1000);
+  scroll_off();
 
+  // scrolling small text
+  time = millis();
   display.fillScreen(BLACK);
   display.setCursor(0,0);
-  display.print("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur adipiscing ante sed nibh tincidunt feugiat. Maecenas enim massa");
-  delay(1000);
+#ifdef SSD1331_EXTRAS
+  display.setTextScroll(true);
+#endif
+  for (int i = 0; i < 10; i++) {
+    display.print("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur adipiscing ante sed nibh tincidunt feugiat. Maecenas enim massa");
+  }
+  time = millis() - time;
+  Serial.printf("Small text scrolling test took %ldms\r\n", time);
+  display.setTextColor(GREEN);
+  display.printf("\r\n-> %ldms", time);
+#ifdef SSD1331_EXTRAS
+  display.setTextScroll(false);
+#endif
+  delay(2000);
+  scroll_off();
+
+  // scrolling big text
+  time = millis();
+  display.fillScreen(BLACK);
+  display.setCursor(0,0);
+#ifdef SSD1331_EXTRAS
+  display.setTextScroll(true);
+#endif
+  display.setTextSize(2);
+  display.setTextColor(BLUE);
+  for (int i = 0; i < 10; i++) {
+    display.print("Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur adipiscing ante sed nibh tincidunt feugiat. Maecenas enim massa");
+  }
+  time = millis() - time;
+  Serial.printf("Large text scrolling test took %ldms\r\n", time);
+  display.setTextColor(GREEN);
+  display.printf("\r\n%ldms", time);
+#ifdef SSD1331_EXTRAS
+  display.setTextScroll(false);
+#endif
+  display.setTextSize(1);
+  delay(2000);
+  scroll_off();
 
   // tft print function!
+  time = millis();
   tftPrintTest();
+  // The print test contains a 1500ms delay.
+  Serial.printf("Print test took %ldms\r\n", (millis() - time) - 1500);
   delay(2000);
-
+  scroll_off();
+  
   //a single pixel
   display.drawPixel(display.width()/2, display.height()/2, GREEN);
   delay(500);
+  scroll_off();
 
   // line draw test
+  time = millis();
   testlines(YELLOW);
+  // The lines test contains four 250ms delays.
+  Serial.printf("Lines test took %ldms\r\n", (millis() - time) - 1000);
   delay(500);
+  scroll_off();
 
   // optimized lines
+  time = millis();
   testfastlines(RED, BLUE);
+  Serial.printf("Optimized Lines test took %ldms\r\n", millis() - time);
   delay(500);
+  scroll_off();
 
+  time = millis();
   testdrawrects(GREEN);
-  delay(1000);
+  Serial.printf("Drawrects test took %ldms\r\n", millis() - time);
+  delay(500);
+  scroll_off();
 
+  time = millis();
   testfillrects(YELLOW, MAGENTA);
-  delay(1000);
+  Serial.printf("Fillrects test took %ldms\r\n", millis() - time);
+  delay(500);
+  scroll_off();
 
+  time = millis();
   display.fillScreen(BLACK);
   testfillcircles(10, BLUE);
   testdrawcircles(10, WHITE);
-  delay(1000);
+  Serial.printf("Circles test took %ldms\r\n", millis() - time);
+  delay(500);
+  scroll_off();
 
+  time = millis();
   testroundrects();
+  Serial.printf("Round rects test took %ldms\r\n", millis() - time);
   delay(500);
+  scroll_off();
 
+  time = millis();
   testtriangles();
+  Serial.printf("Triangles test took %ldms\r\n", millis() - time);
   delay(500);
+  scroll_off();
 
-  Serial.println("done");
+  Serial.printf("*** done ***\r\n\r\n");
   delay(1000);
 }
 
-void loop() {
-}
 
 void testlines(uint16_t color) {
    display.fillScreen(BLACK);
@@ -119,6 +195,7 @@ void testlines(uint16_t color) {
    for (int16_t y=0; y < display.height()-1; y+=6) {
      display.drawLine(0, 0, display.width()-1, y, color);
    }
+   delay(250);
 
    display.fillScreen(BLACK);
    for (int16_t x=0; x < display.width()-1; x+=6) {
@@ -127,6 +204,7 @@ void testlines(uint16_t color) {
    for (int16_t y=0; y < display.height()-1; y+=6) {
      display.drawLine(display.width()-1, 0, 0, y, color);
    }
+   delay(250);
 
    // To avoid ESP8266 watchdog timer resets when not using the hardware SPI pins
    delay(0);
@@ -138,6 +216,7 @@ void testlines(uint16_t color) {
    for (int16_t y=0; y < display.height()-1; y+=6) {
      display.drawLine(0, display.height()-1, display.width()-1, y, color);
    }
+   delay(250);
 
    display.fillScreen(BLACK);
    for (int16_t x=0; x < display.width()-1; x+=6) {
@@ -146,6 +225,7 @@ void testlines(uint16_t color) {
    for (int16_t y=0; y < display.height()-1; y+=6) {
      display.drawLine(display.width()-1, display.height()-1, 0, y, color);
    }
+   delay(250);
 
 }
 
@@ -174,14 +254,16 @@ void testfastlines(uint16_t color1, uint16_t color2) {
 
 void testdrawrects(uint16_t color) {
  display.fillScreen(BLACK);
- for (int16_t x=0; x < display.height()-1; x+=6) {
+ int size = ((display.height() > display.width())?display.width():display.height()) - 1;
+ for (int16_t x=0; x < size; x+=6) {
    display.drawRect((display.width()-1)/2 -x/2, (display.height()-1)/2 -x/2 , x, x, color);
  }
 }
 
 void testfillrects(uint16_t color1, uint16_t color2) {
  display.fillScreen(BLACK);
- for (int16_t x=display.height()-1; x > 6; x-=6) {
+ int size = ((display.height() > display.width())?display.width():display.height()) - 1;
+ for (int16_t x=size; x > 6; x-=6) {
    display.fillRect((display.width()-1)/2 -x/2, (display.height()-1)/2 -x/2 , x, x, color1);
    display.drawRect((display.width()-1)/2 -x/2, (display.height()-1)/2 -x/2 , x, x, color2);
  }
@@ -304,23 +386,23 @@ void mediabuttons() {
 void lcdTestPattern(void)
 {
   uint8_t w,h;
-  display.setAddrWindow(0, 0, 96, 64);
-
-  for (h = 0; h < 64; h++) {
-    for (w = 0; w < 96; w++) {
-      if (w > 83) {
+  display.startWrite();
+  int stripe_width = (display.width() / 8);
+  for (h = 0; h < display.height() - 1; h++) {
+    for (w = 0; w < display.width() - 1; w++) {
+      if (w > stripe_width * 7) {
         display.writePixel(w, h, WHITE);
-      } else if (w > 71) {
+      } else if (w > stripe_width * 6) {
         display.writePixel(w, h, BLUE);
-      } else if (w > 59) {
+      } else if (w > stripe_width * 5) {
         display.writePixel(w, h, GREEN);
-      } else if (w > 47) {
+      } else if (w > stripe_width * 4) {
         display.writePixel(w, h, CYAN);
-      } else if (w > 35) {
+      } else if (w > stripe_width * 3) {
         display.writePixel(w, h, RED);
-      } else if (w > 23) {
+      } else if (w > stripe_width * 2) {
         display.writePixel(w, h, MAGENTA);
-      } else if (w > 11) {
+      } else if (w > stripe_width) {
         display.writePixel(w, h, YELLOW);
       } else {
         display.writePixel(w, h, BLACK);
@@ -328,4 +410,62 @@ void lcdTestPattern(void)
     }
   }
   display.endWrite();
+}
+
+void scroll_off()
+{
+#ifdef SSD1331_EXTRAS
+  int width = display.width();
+  int height = display.height();
+  int scroll_amount = 1;
+  int xscroll = 0;
+  int yscroll = 0;
+  int count = 0;
+  int clearx = 0;
+  int cleary = 0;
+  int clearw = width;
+  int clearh = height;
+  static int direction = 0;
+
+  switch(direction)
+  {
+  case 0:
+    // scroll up
+    yscroll = -scroll_amount;
+    count = height / scroll_amount;
+    cleary = (height - 1) - scroll_amount;
+    clearh = scroll_amount;
+  break;
+  case 1:
+    // scroll right
+    xscroll = scroll_amount;
+    count = width / scroll_amount;
+    clearw = scroll_amount;
+  break;
+  case 2:
+    // scroll down
+    yscroll = scroll_amount;
+    count = height / scroll_amount;
+    clearh = scroll_amount;
+  break;
+  case 3:
+    // scroll left
+    xscroll = -scroll_amount;
+    count = width / scroll_amount;
+    clearx = (width - 1) - scroll_amount;
+    clearw = scroll_amount;
+  break;
+  }
+
+  for (int i = 0; i < count; i++)
+  {
+    display.copyBits(0, 0, width, height, xscroll, yscroll);
+    display.fillRect(clearx, cleary, clearw, clearh, 0);
+  }
+
+  // Increment the scroll direction each time.
+  direction += 1;
+  direction &= 0x03;
+  delay(500);
+#endif
 }


### PR DESCRIPTION
This PR adds full acceleration using the on-chip acceleration commands in the SSD1331.
All 4 rotations are supported, and everything is immensely faster.  
I've also added a copyBits() function that does an on-device bitblit (copies a rectangle of pixels within the screen buffer), and an optional setTextScroll() method that, when set to true, will cause the screen to scroll when printed text goes below the bottom of the screen so that further printing is visible. These additions are behind #ifdef SSD1331_EXTRAS, which is defined in the Adafruit_SSD1331.h header.

Before/after test timings from the modified test.ino and LCDGFXDemo.ino included in the PR (taken with the code running on a QT Py M0, with `display.begin(MAX_SPI);`:

test.ino before:
```
Test pattern took 675ms
Print test took 214ms
Lines test took 1024ms
Optimized Lines test took 31ms
Drawrects test took 28ms
Fillrects test took 80ms
Circles test took 173ms
Round rects test took 231ms
Triangles test took 142ms
```

test.ino after:

```
Test pattern took 118ms
Print test took 45ms
Lines test took 10ms
Optimized Lines test took 2ms
Drawrects test took 2ms
Fillrects test took 7ms
Circles test took 28ms
Round rects test took 35ms
Triangles test took 3ms
```

LCDGFXDemo.ino  before:
```
Speed test number of ms: 787
FPS: 50.83
bounce 32 bitmap
Scroll test number of ms: 27027
FPS: 7
bounce 32 bitmap no clear
Scroll test number of ms: 23111
FPS: 8
pan/bounce 24 bitmap
Scroll test number of ms: 16920
FPS: 11
pan/bounce 24 bitmap no clear
Scroll test number of ms: 13003
FPS: 15
pan/bounce 8 bitmap
Scroll test number of ms: 4053
FPS: 49
pan/bounce 8 bitmap
Scroll test number of ms: 136
FPS: 1470

Count pixels
Speed test number of ms: 7951
FPS: 1.26
Count pixels done

Count_writePixels
Speed test number of ms: 244
FPS: 40.98
Count_writePixels done
```

LCDGFXDemo.ino after:
```
Speed test number of ms: 64
FPS: 625.00
bounce 32 bitmap
Scroll test number of ms: 4246
FPS: 47
bounce 32 bitmap no clear
Scroll test number of ms: 3932
FPS: 50
pan/bounce 24 bitmap
Scroll test number of ms: 2528
FPS: 79
pan/bounce 24 bitmap no clear
Scroll test number of ms: 2214
FPS: 90
pan/bounce 8 bitmap
Scroll test number of ms: 431
FPS: 464
pan/bounce 8 bitmap
Scroll test number of ms: 117
FPS: 1709

Count pixels
Speed test number of ms: 2037
FPS: 4.91
Count pixels done

Count_writePixels
Speed test number of ms: 247
FPS: 40.49
Count_writePixels done
```
